### PR TITLE
Documentação API NFSeR (out-of-beta)

### DIFF
--- a/source/includes/_nfses-recebidas.md
+++ b/source/includes/_nfses-recebidas.md
@@ -1,6 +1,6 @@
 # NFSes Recebidas
 
-De forma similar à [manifestação de NFe](#manifestacao-nfe), a API Focus para busca de _NFSes Recebidas_ permite que você consulte notas de serviço em que sua empresa é a tomadora do serviço. Aqui chamamos de _notas recebidas_ pois NFSe não contempla a operação de manifestação.
+De forma similar à [manifestação de NFe](#manifestacao-nfe), a API Focus para busca de _NFSes Recebidas_ permite que você consulte notas de serviço em que sua empresa é a tomadora do serviço. Denominamos _notas recebidas_ pois NFSe não contempla a operação de manifestação.
 
 A recuperação de notas é possível apenas em municípios que disponibilizam a consulta de notas recebidas / tomadas - como São Paulo, Sorocaba, Barueri e outras dezenas de [municípios integrados em nossa API](https://focusnfe.com.br/cidades-integradas-nfse/).
 
@@ -389,7 +389,7 @@ Você pode configurar o gatilho `nfse_recebida` para receber estes dados diretam
 ]
 ```
 
-Caso utilize o argumento `completa=1`, os dados serão devolvidos em formato estendido, similar ao de emissão de NFSe com algumas melhorias. Para mais detalhes consulte a [Documentação Completa de Campos NFSes Recebidas](LINK_PARA_DOCUMENTACAO_COMPLETA_DE_CAMPOS). Informações adicionais na seção [Versões da API](#nfses-recebidas_versoes-da-api).
+Caso utilize o argumento `completa=1`, os dados serão devolvidos em formato estendido, similar ao de emissão de NFSe com algumas melhorias. Para mais detalhes consulte a [Documentação Completa de Campos NFSes Recebidas](https://campos.focusnfe.com.br/nfser/NfseRecebida.html). Informações adicionais na seção [Versões da API](#nfses-recebidas_versoes-da-api).
 
 
 ## Consulta de NFSe Individual
@@ -417,7 +417,7 @@ Para garantir compatibilidade, é possível consultar dados de _versões especí
 api_version | Padrão | Descrição | Links
 ------------|:------:|-----------|------:
 2020-11-17  |   | Versão preliminar (beta) | [documentação legada](https://github.com/FocusNFe/api-doc/blob/v2.4.3/source/includes/_nfses-recebidas.md#dados-devolvidos)
-2023-03-01  | * | Primeira versão oficial estável | [changelog](LINK_BLOG), [documentação atual](LINK_PARA_DOCUMENTACAO_COMPLETA_DE_CAMPOS)
+2023-03-01  | * | Primeira versão oficial estável | [changelog](LINK_BLOG), [documentação atual](https://campos.focusnfe.com.br/nfser/NfseRecebida.html)
 
 <small>
 (*) Última versão estável da API de _NFSes Recebidas_, assumida como padrão quando não informado o parâmetro.

--- a/source/includes/_nfses-recebidas.md
+++ b/source/includes/_nfses-recebidas.md
@@ -404,7 +404,7 @@ Isto irá devolver os mesmos campos da nota completa, conforme descritos na [se�
 
 ## Versões da API
 
-> Exemplo de consulta de NFSe a ser devolvida no formato da versão beta da API:
+> Exemplo de consulta de NFSe a ser devolvida no formato da versão _beta_ da API:
 
 ```shell
 curl -u "token obtido no cadastro da empresa:" \
@@ -414,12 +414,12 @@ curl -u "token obtido no cadastro da empresa:" \
 Eventualmente são integradas melhorias nos dados retornados pela API de _NFSes Recebidas_.
 Para garantir compatibilidade, é possível consultar dados de _versões específicas da API_ informando o parâmetro **api_version**.
 
-api_version | Padrão | Descrição | Links
-------------|:------:|-----------|------:
-2020-11-17  |   | Versão preliminar (beta) | [documentação legada](https://github.com/FocusNFe/api-doc/blob/v2.4.3/source/includes/_nfses-recebidas.md#dados-devolvidos)
-2023-03-01  | * | Primeira versão oficial estável | [changelog](LINK_BLOG), [documentação atual](https://campos.focusnfe.com.br/nfser/NfseRecebida.html)
+api_version | Padrão¹ | Descrição | Links | <abbr title="End of Life">EOL</abbr>
+------------|:-------:|:---------:|:----: | -----:
+`2020-11-17` | **x**<br><small>_(até 1/10/2023)_</small> | Versão preliminar (beta) | [documentação legada](https://github.com/FocusNFe/api-doc/blob/v2.6.3/source/includes/_nfses-recebidas.md#dados-devolvidos) | 01/10/2024
+`2023-03-01` |  | Primeira versão oficial | [documentação](https://campos.focusnfe.com.br/nfser/NfseRecebida.html), [changelog](LINK_BLOG) | -
+<small>(¹) Última versão estável da API de _NFSes Recebidas_, assumida como padrão quando não informado o parâmetro.</small>
 
-<small>
-(*) Última versão estável da API de _NFSes Recebidas_, assumida como padrão quando não informado o parâmetro.
-</small>
-
+<aside class="notice">
+A partir do dia <i>2/10/2023</i> a versão padrão será <code>2023-03-01</code>. Recomendamos que especifique a versão da API em seu sistema.
+</aside>

--- a/source/includes/_nfses-recebidas.md
+++ b/source/includes/_nfses-recebidas.md
@@ -417,7 +417,7 @@ Para garantir compatibilidade, é possível consultar dados de _versões especí
 api_version | Padrão¹ | Descrição | Links | <abbr title="End of Life">EOL</abbr>
 ------------|:-------:|:---------:|:----: | -----:
 `2020-11-17` | **x**<br><small>_(até 1/10/2023)_</small> | Versão preliminar (beta) | [documentação legada](https://github.com/FocusNFe/api-doc/blob/v2.6.3/source/includes/_nfses-recebidas.md#dados-devolvidos) | 01/10/2024
-`2023-03-01` |  | Primeira versão oficial | [documentação](https://campos.focusnfe.com.br/nfser/NfseRecebida.html), [changelog](LINK_BLOG) | -
+`2023-03-01` |  | Primeira versão oficial | [documentação](https://campos.focusnfe.com.br/nfser/NfseRecebida.html), [changelog](https://focusnfe.com.br/blog/changelog-nfser-v2023-03-01/) | -
 <small>(¹) Última versão estável da API de _NFSes Recebidas_, assumida como padrão quando não informado o parâmetro.</small>
 
 <aside class="notice">

--- a/source/includes/_nfses-recebidas.md
+++ b/source/includes/_nfses-recebidas.md
@@ -1,19 +1,23 @@
-# NFSes recebidas (beta)
+# NFSes Recebidas
 
-Da mesma forma que a manifestação de NFe, a API para busca de NFSes recebidas do sistema Focus permite que você consulte as notas de serviço onde sua empresa é a tomadora do serviço nos municípios onde isso é possível. No caso da NFSe, não existe a operação de manifestação. No momento a busca de notas está sendo possível apenas no município de São Paulo.
+De forma similar à [manifestação de NFe](#manifestacao-nfe), a API Focus para busca de _NFSes Recebidas_ permite que você consulte notas de serviço em que sua empresa é a tomadora do serviço. Aqui chamamos de _notas recebidas_ pois NFSe não contempla a operação de manifestação.
 
-Através desta documentação deverá ser possível fazer a integração com a API do Focus NFe, caso alguma dúvida permaneça você pode entrar em contato com o suporte através do e-mail suporte@focusnfe.com.br. Através deste canal você pode também solicitar a implementação de algum município que possibilite a busca de notas recebidas de forma automática.
+A recuperação de notas é possível apenas em municípios que disponibilizam a consulta de notas recebidas / tomadas - como São Paulo, Sorocaba, Barueri e outras dezenas de [municípios integrados em nossa API](https://focusnfe.com.br/cidades-integradas-nfse/).
+
+A presente documentação deve ser suficiente para realizar a integração com a API do Focus NFe. Em caso de dúvidas, entre em contato com nosso excelente suporte pelo e-mail suporte@focusnfe.com.br. Neste canal você também pode verificar a viabilidade de integração de novos municípios.
+
 
 ## URLs
 
-
 Método | URL (recurso) | Ação
 -------|---------------|------
-GET|/v2/nfses_recebidas?cnpj=CNPJ|Busca os dados de todas as NFSes recebidas.
+GET | /v2/nfses_recebidas?cnpj=CNPJ  | Busca os dados de todas as NFSes recebidas para o CNPJ
+GET | /v2/nfses_recebidas/CHAVE      | Consulta a nota fiscal completa identificada pela chave informada
+
 
 ## Status API
 
-Aqui você encontra os status possíveis para MDe.
+Aqui você encontra os status possíveis para NFSes Recebidas.
 
 HTTP CODE/STATUS | Status API Focus | Descrição | Correção
 ---|---|---|---|
@@ -21,15 +25,19 @@ HTTP CODE/STATUS | Status API Focus | Descrição | Correção
 400 - bad request | requisicao_invalida | CNPJ/UF do emitente não autorizado ou não informado. | Verifique no Painel API se esse emitente está habilitado para realizar a busca de NFSes recebidas. Verifique se o CNPJ foi informado no JSON de envio.
 403 - forbidden | permissao_negada | CNPJ do emitente não autorizado. | O emitente utilizado não está autorizado a realizar a operação de busca ou foi informado o CNPJ do emitente incorretamente no JSON.
 
+
 ## Consulta de NFSe Recebidas
 
-Uma NFSe pode ser cancelada após ter sido recebida. Por este motivo as NFSes recebidas possuem um campo chamado “**versao**” que é único entre todos os documentos do mesmo CNPJ e que é atualizado a cada alteração nesta NFSe. Isto facilita a busca apenas dos documentos que seu sistema ainda não conhece, sendo necessário que você armazene apenas um número por CNPJ.
+As NFSes recebidas possuem um campo chamado "**versao**", que é único entre todos os documentos recebidos do mesmo CNPJ.
+Isto permite buscar apenas documentos que seu sistema não conhece, mantendo um único número incremental por CNPJ.
 
-Por exemplo, se você recebe uma NFSe com versao = 60, e ela posteriormente for cancelada, sua versão será atualizada para algum número maior que 60.
+Como uma NFSe pode ser cancelada após ter sido recebida, a **versao** associada é atualizada a cada alteração nesta NFSe.
+Por exemplo, se você recebe uma NFSe com `versao: 60` e ela posteriormente for cancelada, a versão da NFSe será atualizada para algum número maior que `60`.
 
-A API busca as últimas atualizações das prefeituras uma vez ao dia.
+A API busca notas recentes nas prefeituras duas vezes por dia. Atualizações retroativas, como cancelamentos de notas mais antigas, são buscadas aos finais de semana.
 
-**Método de consulta**
+
+### Método de Consulta
 
 > Exemplo de como consultar todas as notas recebidas de uma empresa.
 
@@ -59,6 +67,7 @@ print(r.status_code, r.text)
 curl -u "token obtido no cadastro da empresa:" \
   "https://homologacao.focusnfe.com.br/v2/nfses_recebidas?cnpj=SEU_CNPJ"
 ```
+
 
 ```java
 import com.sun.jersey.api.client.Client;
@@ -99,8 +108,8 @@ public class ConsultarTodosManifestos {
 }
 ```
 
-```ruby
 
+```ruby
 # encoding: UTF-8
 
 require "net/http"
@@ -145,6 +154,7 @@ puts "Corpo da resposta: " + resposta.body
 
 ```
 
+
 ```php
 <?php
 // Solicite o seu token para realizar as requisições com nossa equipe de suporte.
@@ -172,8 +182,8 @@ puts "Corpo da resposta: " + resposta.body
 ?>
 ```
 
-```javascript
 
+```javascript
 /*
 A orientacao a seguir foram extraidas do site do NPMJS: https://www.npmjs.com/package/xmlhttprequest
 Here's how to include the module in your project and use as the browser-based XHR object.
@@ -211,123 +221,205 @@ Para consultar os documentos fiscais recebidos, utilize o endereço abaixo:
 
 `https://api.focusnfe.com.br/v2/nfses_recebidas?cnpj=CNPJ`
 
-Utilize o método **HTTP GET** para consultar as notas. Esta requisição aceita os seguintes parâmetros que deverão ser enviados na URL:
+Utilize o método **HTTP GET** para consultar as notas. Esta requisição aceita os seguintes parâmetros na URL:
 
 * **cnpj**(*): CNPJ da empresa. Campo obrigatório.
-* **versao**: Se informado, irá buscar apenas os documentos cuja versão seja maior que o parâmetro recebido. Utilize este parâmetro para buscar apenas as notas que seu sistema ainda não conhece.
-* **completa**: Se informado com o valor "1" irá devolver os dados completos do XML da nota, seguindo o padrão dos dados enviados para emissão de NFSe. Caso contrário, irá devolver os dados de forma resumida conforme descrito na próxima seção.
+* **versao**: Se informado, busca apenas os documentos cuja versão seja maior que o parâmetro recebido. Utilize este parâmetro para buscar apenas as notas que seu sistema ainda não conhece.
+* **completa**: Se informado com o valor "1", devolve os dados completos do XML da nota. Caso contrário, devolve os dados resumidos de forma simplificada, conforme descrito na próxima seção.
+* **api_version**: Se informado, devolve os dados estruturados conforme seção [Versões da API](#nfses-recebidas_versoes-da-api). Caso contrário, adota a última versão estável.
 
-Serão devolvidas as 100 primeiras notas encontradas. Para recuperar as demais notas você deverá fazer uma nova requisição alterando o campo versão.
+Serão devolvidas as 100 primeiras notas encontradas. Para recuperar as demais notas você deverá fazer uma nova requisição alterando o campo **versão**.
 
 > Exemplo dos dados de resposta:
 
 ```json
 [
   {
-    "numero": 3240,
-    "numero_rps": 3187,
-    "serie_rps": "UNICA",
-    "data_emissao": "2019-11-01T09:53:01-03:00",
-    "data_emissao_rps": "2019-11-01T00:00:00-03:00",
-    "valor_total": 63.5,
-    "situacao": "autorizada",
-    "documento_prestador": "11131112000133",
-    "nome_prestador": null,
-    "inscricao_municipal_prestador": "12224222",
-    "versao": 123,
-    "codigo_verificacao": "IAAAXAAB",
-    "url": "https://nfe.prefeitura.sp.gov.br/contribuinte/notaprint.aspx?inscricao=12224222&nf=3240&verificacao=IAAAXAAA",
-    "url_xml": "https://focusnfe.s3-sa-east-1.amazonaws.com/arquivos/11110100000111/201911/NFSeRecebidas/NFSe111101000001113220308-12224222-3240-IAAAXAAA.xml",
-    "nome_municipio": "São Paulo",
-    "sigla_uf": "SP",
-    "codigo_municipio": "3550308"
+    "chave": "NFSe945710720005664305108-162458-162950-43945710720005669000S000162950218736215",
+    "versao": 846,
+    "status": "autorizado",
+    "numero": "162950",
+    "numero_rps": "218736215",
+    "serie_rps": "S",
+    "data_emissao": "2023-02-23T21:02:00-03:00",
+    "data_emissao_rps": "2023-02-23T21:02:00-03:00",
+    "codigo_verificacao": "43945710720005669000S000162950218736215",
+    "valor_servicos": "473.27",
+    "documento_prestador": "94571072000566",
+    "nome_prestador": "TRANSPORTADORA KALINCA LTDA",
+    "inscricao_municipal_prestador": "162458",
+    "nome_municipio": "Caxias do Sul",
+    "sigla_uf": "RS",
+    "codigo_municipio": "4305108",
+    "documento_tomador": "88610126000129",
+    "url": "https://nfse.caxias.rs.gov.br/services/nfse/public/consulta/pdf?chaveAcesso=43945710720005669000S000162950218736215",
+    "url_xml": "https://focusnfe.s3.sa-east-1.amazonaws.com/arquivos_development/88610126000129/202302/NFSeRecebidas/NFSe945710720005664305108-162458-162950-43945710720005669000S000162950218736215.xml"
   }
 ]
 ```
 
-**Dados devolvidos**
+### Dados Devolvidos
 
 A API irá devolver os seguintes cabeçalhos HTTP:
 
 * **X-Total-Count**: O número total de registros (incluindo aqueles que não foram devolvidos pelo limite de 100 registros)
 * **X-Max-Version**: Valor máximo da versão dos documentos devolvidos. Utilize este cabeçalho para utilizar na próxima busca de versão, caso seja necessário.
 
-Os dados devolvidos podem vir em dois formatos: modo simplificado (default) e completo.
+Os dados devolvidos podem vir em dois formatos: modo simplificado (default) ou completo.
 Se utilizado o formato simplificado o corpo da resposta será um array de objetos em JSON no seguinte formato:
 
+* **chave**: Chave única de identificação da NFSe.
+* **versao**: Versão do documento fiscal. Este número irá mudar apenas se o documento for alterado de alguma forma.
+* **status**: Status do documento fiscal. Pode ser _autorizado_ ou _cancelado_.
 * **numero**: Número da NFSe.
 * **numero_rps**: Número do RPS, se existir.
 * **serie_rps**: Série do RPS, se existir.
 * **data_emissao**: Data de emissão da NFSe.
 * **data_emissao_rps**: Data de emissão do RPS, se existir.
-* **valor_total**: Valor total da NFSe.
-* **situacao**: Situação da NFSe. Pode ser: autorizada ou cancelada.
-* **documento_prestador**: CNPJ ou CPF do emitente do documento fiscal.
-* **inscricao_municipal_prestador**: CNPJ ou CPF do emitente do documento fiscal.
-* **versao**: Versão do documento fiscal. Este número irá mudar apenas se o documento for alterado de alguma forma.
 * **codigo_verificacao**: Código de verificação da NFSe.
-* **url**: URL para visualização da NFSe no site da prefeitura.
-* **url_xml**: URL para download do XML da NFSe.
+* **valor_servicos**: Valor total dos serviços da NFSe.
+* **documento_prestador**: CNPJ ou CPF do emitente do documento fiscal.
+* **nome_prestador**: Razão Social ou Nome do emitente do documento fiscal, se existir.
+* **inscricao_municipal_prestador**: Inscrição Municipal do emitente do documento fiscal, se existir.
 * **nome_municipio**: Nome do município do prestador.
 * **sigla_uf**: UF do prestador.
 * **codigo_municipio**: Código IBGE do município do prestador.
+* **documento_tomador**: CNPJ ou CPF do destinatário do documento fiscal.
+* **url**: URL para visualização da NFSe no site da prefeitura.
+* **url_xml**: URL para download do XML da NFSe.
 
-Você pode também configurar o gatilho "nfse_recebida" para receber estes dados resumidos diretamente em sua aplicação assim que estiverem disponíveis na API. Consulte a seção de [Gatilhos / Webhooks](#gatilhos-webhooks).
+Você pode configurar o gatilho `nfse_recebida` para receber estes dados diretamente em sua aplicação, tão logo estejam disponíveis na API. Consulte a seção de [Gatilhos / Webhooks](#gatilhos-webhooks).
 
-> Exemplo dos dados de resposta usando o parâmetro completa=1:
+> Exemplo dos dados de resposta usando o parâmetro `completa=1`:
 
 ```json
 [
   {
-    "numero": "3240",
-    "codigo_verificacao": "HT9MPFM1",
-    "numero_rps": "3187",
-    "serie_rps": "1",
-    "tipo_rps":  "RPS",
-    "status": "N",
-    "situacao": "autorizada",
-    "versao": 123,
+    "chave": "NFSe945710720005664305108-162458-162950-43945710720005669000S000162950218736215",
+    "versao": 846,
+    "status": "autorizado",
+    "numero": "162950",
+    "serie": "S",
+    "codigo_verificacao": "43945710720005669000S000162950218736215",
+    "data_emissao": "2023-02-23T21:02:00-03:00",
+    "numero_rps": "218736215",
+    "serie_rps": "S",
+    "tipo_rps": null,
+    "data_emissao_rps": "2023-02-23T21:02:00-03:00",
+    "natureza_operacao": null,
+    "regime_especial_tributacao": "3",
+    "optante_simples_nacional": false,
+    "incentivador_cultural": null,
+    "competencia": null,
+    "numero_nfse_substituida": null,
+    "outras_informacoes": null,
+    "informacoes_adicionais_contribuinte": "REMETENTE: 08304706000159 - CASTERTECH FUNDICAO E TECNOLOGIA LTDA;DESTINATARIO: 88610126000129 - FRAS-LE SA;VEICULO: ICH3722;MOTORISTA: PAULO FERNANDES DE OLIVEIRA;",
     "prestador": {
-      "cnpj": "11131112000133",
-      "inscricao_municipal": "12224222"
-    },
-    "tomador": {
-      "razao_social": "Tomador Ltda",
-      "cnpj": "11131112000134",
-      "inscricao_municipal": null,
+      "cpf": null,
+      "cnpj": "94571072000566",
+      "inscricao_municipal": "162458",
+      "razao_social": "TRANSPORTADORA KALINCA LTDA",
+      "nome_fantasia": "KALINCA FILIAL 5",
+      "telefone": "5430256313",
+      "email": null,
       "endereco": {
-        "nome_municipio": "Florianópolis",
-        "bairro": "Bom Retiro",
-        "cep": "89223001",
-        "codigo_municipio": null,
-        "logradouro": "AV Santos Dumont",
-        "numero": "22",
-        "uf": "SC"
+        "logradouro": "CAVALIERE AMBROGIO CIPOLLA",
+        "numero": "383",
+        "complemento": null,
+        "bairro": "MARILAND",
+        "codigo_municipio": "4305108",
+        "nome_municipio": "CAXIAS DO SUL",
+        "uf": "RS",
+        "codigo_pais": "1058",
+        "cep": "95057000"
       }
     },
-    "data_emissao": "2019-11-01T09:53:01-03:00",
-    "optante_simples_nacional": "",
-    "incentivador_cultural": "",
-    "valor_liquido": "450",
-    "servico": {
-      "valor_servicos": "450",
-      "valor_deducoes": null,
-      "valor_pis": "2.93",
-      "valor_cofins": "13.5",
-      "valor_inss": null,
-      "valor_ir": null,
-      "valor_csll": "4.5",
-      "valor_iss": 22.5,
-      "item_lista_servico": "3123",
-      "aliquota": "0.0500",
-      "iss_retido": "false",
-      "discriminacao": "Prestação de serviço",
-      "codigo_municipio": null
-    }
+    "tomador": {
+      "cpf": null,
+      "cnpj": "88610126000129",
+      "inscricao_municipal": null,
+      "razao_social": "FRASLE SA",
+      "telefone": "5432390100",
+      "email": "nfe_fretes@randon.com.br",
+      "endereco": {
+        "logradouro": "RODOVIA RS 122",
+        "numero": "10945",
+        "complemento": "KM 66 1",
+        "bairro": "FORQUETA",
+        "codigo_municipio": "4305108",
+        "nome_municipio": "CAXIAS DO SUL",
+        "uf": "RS",
+        "codigo_pais": "1058",
+        "cep": "95115550"
+      }
+    },
+    "servicos": [
+      {
+        "valor_servicos": "473.27",
+        "valor_deducoes": "0.00",
+        "valor_pis": "0.00",
+        "valor_cofins": "0.00",
+        "valor_inss": "0.00",
+        "valor_ir": "0.00",
+        "valor_csll": "0.00",
+        "iss_retido": false,
+        "valor_iss": "18.93",
+        "valor_iss_retido": "0.00",
+        "outras_retencoes": null,
+        "base_calculo": "473.27",
+        "aliquota": "4.0000",
+        "valor_liquido": "473.27",
+        "valor_credito": null,
+        "desconto_incondicionado": "0.00",
+        "desconto_condicionado": null,
+        "item_lista_servico": "16.02",
+        "codigo_cnae": null,
+        "codigo_tributario_municipio": "8394",
+        "discriminacao": "PREST DE SERV DE TRANSP Dados Adic. Nro NFs:424141.424140; VOLUMES:48.00; PESO:22180.000; VLR TOT. MERC.:454.60",
+        "codigo_municipio": "4305108",
+        "codigo_pais": null,
+        "codigo_municipio_incidencia": null,
+        "quantidade": "1.00",
+        "valor_unitario": "473.27"
+      }
+    ],
+    "url": "https://nfse.caxias.rs.gov.br/services/nfse/public/consulta/pdf?chaveAcesso=43945710720005669000S000162950218736215",
+    "url_xml": "https://focusnfe.s3.sa-east-1.amazonaws.com/arquivos_development/88610126000129/202302/NFSeRecebidas/NFSe945710720005664305108-162458-162950-43945710720005669000S000162950218736215.xml"
   }
 ]
 ```
 
-Caso utilize o argumento "completa=1" os dados serão devolvidos no mesmo
-[formato de emissão de NFSe](#nfse_campos). Acrescentado dos campos "versao" e
-"situacao" descritos acima.
+Caso utilize o argumento `completa=1`, os dados serão devolvidos em formato estendido, similar ao de emissão de NFSe com algumas melhorias. Para mais detalhes consulte a [Documentação Completa de Campos NFSes Recebidas](LINK_PARA_DOCUMENTACAO_COMPLETA_DE_CAMPOS). Informações adicionais na seção [Versões da API](#nfses-recebidas_versoes-da-api).
+
+
+## Consulta de NFSe Individual
+
+Para obter informações completas referentes a uma NFSe específica, consulte informando a _chave_:
+
+`https://api.focusnfe.com.br/v2/nfses_recebidas/CHAVE`
+
+Utilize o método **HTTP GET** para consultar os dados da nota fiscal.
+Isto irá devolver os mesmos campos da nota completa, conforme descritos na [seção anterior](#nfses-recebidas_consulta-de-nfse-recebidas).
+
+
+## Versões da API
+
+> Exemplo de consulta de NFSe a ser devolvida no formato da versão beta da API:
+
+```shell
+curl -u "token obtido no cadastro da empresa:" \
+  "https://homologacao.focusnfe.com.br/v2/nfses_recebidas/CHAVE?api_version=2020-11-17"
+```
+
+Eventualmente são integradas melhorias nos dados retornados pela API de _NFSes Recebidas_.
+Para garantir compatibilidade, é possível consultar dados de _versões específicas da API_ informando o parâmetro **api_version**.
+
+api_version | Padrão | Descrição | Links
+------------|:------:|-----------|------:
+2020-11-17  |   | Versão preliminar (beta) | [documentação legada](https://github.com/FocusNFe/api-doc/blob/v2.4.3/source/includes/_nfses-recebidas.md#dados-devolvidos)
+2023-03-01  | * | Primeira versão oficial estável | [changelog](LINK_BLOG), [documentação atual](LINK_PARA_DOCUMENTACAO_COMPLETA_DE_CAMPOS)
+
+<small>
+(*) Última versão estável da API de _NFSes Recebidas_, assumida como padrão quando não informado o parâmetro.
+</small>
+


### PR DESCRIPTION
Origem: https://redmine.acras.com.br/issues/8934
Require: FocusNFe/gateway/pull/2904

Tira do beta. Finalmente.

Publicar conforme agenda no tkt de origem.

Pendências: 
- [x] Corrigir link do changelog (`LINK_BLOG`)