### PR TITLE
Adiciona "optante_simples_nacional", "optante_mei", "complemento", "codigo_siafi" e "codigo_ibge" na documentação da API de CNPJs

### DIFF
--- a/source/includes/_cnpjs.md
+++ b/source/includes/_cnpjs.md
@@ -194,6 +194,8 @@ A requisição REST devolve um JSON no corpo (body) da resposta com seguintes da
     "optante_mei": false,
     "endereco": {
       "codigo_municipio": "7535",
+      "codigo_siafi": "7535",
+      "codigo_ibge": "4106902",
       "nome_municipio": "CURITIBA",
       "logradouro": " XV DE NOVEMBRO",
       "complemento": "Conj 602 Andar 06 Cond Eugenia Campos Ed",
@@ -213,7 +215,9 @@ Para cada consulta à API de CNPJs a resposta trará um objeto JSON, com os camp
  * **cnae_principal**: CNAE Principal.
  * **optante_simples_nacional**: Indica se a empresa é optante pelo Simples Nacional.
  * **optante_mei**: Indica se a empresa é optante pelo MEI.
-  * **codigo_municipio**: Código do município onde a empresa está registrada.
+  * **codigo_municipio**: Código Siafi onde a empresa está registrada.
+  * **codigo_siafi**: Código Siafi onde a empresa está registrada.
+  * **codigo_ibge**: Código IBGE onde a empresa está registrada.
   * **nome_municipio**: Nome do município.
   * **logradouro**: Nome do logradouro.
   * **complemento**: Complemento do endereço, se houver.

--- a/source/includes/_cnpjs.md
+++ b/source/includes/_cnpjs.md
@@ -215,7 +215,7 @@ Para cada consulta à API de CNPJs a resposta trará um objeto JSON, com os camp
  * **cnae_principal**: CNAE Principal.
  * **optante_simples_nacional**: Indica se a empresa é optante pelo Simples Nacional.
  * **optante_mei**: Indica se a empresa é optante pelo MEI.
-  * **codigo_municipio**: Código Siafi onde a empresa está registrada.
+  * **codigo_municipio**: Código SIAFI do município onde a empresa está registrada. Este campo será alterado para representar o código IBGE em 1/6/2024. Caso necessite do código SIAFI, use o campo `codigo_siafi`
   * **codigo_siafi**: Código Siafi onde a empresa está registrada.
   * **codigo_ibge**: Código IBGE onde a empresa está registrada.
   * **nome_municipio**: Nome do município.

--- a/source/includes/_cnpjs.md
+++ b/source/includes/_cnpjs.md
@@ -216,7 +216,7 @@ Para cada consulta à API de CNPJs a resposta trará um objeto JSON, com os camp
  * **optante_simples_nacional**: Indica se a empresa é optante pelo Simples Nacional.
  * **optante_mei**: Indica se a empresa é optante pelo MEI.
   * **codigo_municipio**: Código SIAFI do município onde a empresa está registrada. Este campo será alterado para representar o código IBGE em 1/6/2024. Caso necessite do código SIAFI, use o campo `codigo_siafi`
-  * **codigo_siafi**: Código Siafi onde a empresa está registrada.
+  * **codigo_siafi**: Código SIAFI do município onde a empresa está registrada.
   * **codigo_ibge**: Código IBGE onde a empresa está registrada.
   * **nome_municipio**: Nome do município.
   * **logradouro**: Nome do logradouro.

--- a/source/includes/_cnpjs.md
+++ b/source/includes/_cnpjs.md
@@ -190,10 +190,13 @@ A requisição REST devolve um JSON no corpo (body) da resposta com seguintes da
     "cnpj": "07504505000132",
     "situacao_cadastral": "ativa",
     "cnae_principal": "6209100",
+    "optante_simples_nacional": false,
+    "optante_mei": false,
     "endereco": {
       "codigo_municipio": "7535",
       "nome_municipio": "CURITIBA",
       "logradouro": " XV DE NOVEMBRO",
+      "complemento": "Conj 602 Andar 06 Cond Eugenia Campos Ed",
       "numero": "1234",
       "bairro": "CENTRO",
       "cep": "80060000",
@@ -208,9 +211,12 @@ Para cada consulta à API de CNPJs a resposta trará um objeto JSON, com os camp
  * **cnpj**: Número de inscrição no CNPJ.
  * **situacao_cadastral**: Situação cadastral da empresa.
  * **cnae_principal**: CNAE Principal.
+ * **optante_simples_nacional**: Indica se a empresa é optante pelo Simples Nacional.
+ * **optante_mei**: Indica se a empresa é optante pelo MEI.
   * **codigo_municipio**: Código do município onde a empresa está registrada.
   * **nome_municipio**: Nome do município.
   * **logradouro**: Nome do logradouro.
+  * **complemento**: Complemento do endereço, se houver.
   * **numero**: Número do logradouro, se houver.
   * **bairro**: Bairro.
   * **cep**: CEP.

--- a/source/includes/_cnpjs.md
+++ b/source/includes/_cnpjs.md
@@ -217,7 +217,7 @@ Para cada consulta à API de CNPJs a resposta trará um objeto JSON, com os camp
  * **optante_mei**: Indica se a empresa é optante pelo MEI.
   * **codigo_municipio**: Código SIAFI do município onde a empresa está registrada. Este campo será alterado para representar o código IBGE em 1/6/2024. Caso necessite do código SIAFI, use o campo `codigo_siafi`
   * **codigo_siafi**: Código SIAFI do município onde a empresa está registrada.
-  * **codigo_ibge**: Código IBGE onde a empresa está registrada.
+  * **codigo_ibge**: Código IBGE do município onde a empresa está registrada.
   * **nome_municipio**: Nome do município.
   * **logradouro**: Nome do logradouro.
   * **complemento**: Complemento do endereço, se houver.


### PR DESCRIPTION
Origem: https://redmine.acras.com.br/issues/9716
Related: https://github.com/FocusNFe/api_cnpjs/pull/5

![Screenshot from 2023-12-18 10-42-39](https://github.com/FocusNFe/api-doc/assets/104223720/c4bb8b37-e839-4e23-b212-dc0f47feecba)

---

TODOs:

- [ ] Aguardar publicação do lambda (https://github.com/FocusNFe/api_cnpjs/pull/5)

