### PR TITLE
Altera nomenclatura MDe para NFe Recebidas e CTe Recebidas

### DIFF
--- a/source/includes/_manifestacao-cte.md
+++ b/source/includes/_manifestacao-cte.md
@@ -1,6 +1,6 @@
-# Manifestação - CTe
+# CTe recebidas
 
-Da mesma forma que a manifestação de NFe, a API para manifestação de CTe do sistema Focus permite que você consulte todos os conhecimentos de transporte recebidos pela sua empresa e permite que você realize a manifestação frente a receita. No caso da CTe, é necessário realizar a manifestação apenas se houver algum desacordo com a CTe emitida. A API faz ainda a guarda de todos os documentos recebidos para que você consulte quando precisar e recupera todas as MDFes associadas a CTe.
+Da mesma forma que a manifestação de NFe recebidas, a API para CTe recebidas do sistema Focus permite que você consulte todos os conhecimentos de transporte recebidos pela sua empresa e permite que você realize desacordo frente a receita. A API faz ainda a guarda de todos os documentos recebidos para que você consulte quando precisar e recupera todas as MDFes associadas a CTe.
 
 Através desta documentação deverá ser possível fazer a integração com a API do Focus NFe, caso alguma dúvida permaneça você pode entrar em contato com o suporte especializado através do e-mail suporte@focusnfe.com.br.
 
@@ -181,7 +181,7 @@ puts "Corpo da resposta: " + resposta.body
 // Solicite o seu token para realizar as requisições com nossa equipe de suporte.
  $login = "Token_obtido_no_cadastro_da_empresa";
  $chave = "Chave_de_identificação_da_NFe";
-/* Aqui enviamos o tipo de manifestação que desejamos realizar.
+/* Aqui enviamos o desacordo que desejamos realizar.
    Consulte nossa documentação, para conhecer os demais tipos possíveis: https://goo.gl/a9o7hm */
  $tipo = array("observacoes" => "Observações referente ao desacordo informado");
 // Para ambiente de Produção, utilize a URL: https://api.focusnfe.com.br/.
@@ -295,9 +295,9 @@ Caso queria consultar o desacordo realizado, utilize o seguinte endereço:
 
 Utilize o método **HTTP GET** para consultar os dados da nota fiscal.
 
-Na URL, informe em **CHAVE** a chave da CTe recebida. O retorno será o mesmo que a operação de manifestação.
+Na URL, informe em **CHAVE** a chave da CTe recebida. O retorno será o mesmo que a operação de desacordo.
 
-**OBS**: Conforme definido pela SEFAZ na NT 2022.001 do CT-e, se o tomador/destinatário for pessoa física (CPF cadastrado em nossa API para a manifestação do CT-e) não pode registrar o evento de desacordo desse tipo de documento via webservice. Essa ação deve ser realizada exclusivamente através da plataforma gov.br conforme procedimento a seguir:
+**OBS**: Conforme definido pela SEFAZ na NT 2022.001 do CT-e, se o tomador/destinatário for pessoa física (CPF cadastrado em nossa API para CTe recebidas) não poderá registrar o evento de desacordo desse tipo de documento via webservice. Essa ação deve ser realizada exclusivamente através da plataforma gov.br conforme procedimento a seguir:
 
 * Acessar o site: https://dfe-portal.svrs.rs.gov.br/CTE/PrestacaoServicoDesacordo
 * Selecionar a segunda opção: Login pela Plataforma gov.br (Tomador Pessoa Física)

--- a/source/includes/_manifestacao.md
+++ b/source/includes/_manifestacao.md
@@ -1,6 +1,7 @@
-# Manifestação - NFe
+# NFe recebidas
+## Manifestação do Destinatário (MDe)
 
-A API para manifestação do sistema Focus permite que você consulte todas as notas recebidas pela sua empresa (modelo 55) e permite que você realize a manifestação frente a receita, informando se a operação descrita na nota foi realizada ou não. A API faz ainda a guarda de todos os documentos recebidos para que você consulte quando precisar.
+A API para NFe recebidas do sistema Focus permite que você consulte todas as notas recebidas pela sua empresa (modelo 55) e permite que você realize a manifestação frente a receita, informando se a operação descrita na nota foi realizada ou não. A API faz ainda a guarda de todos os documentos recebidos para que você consulte quando precisar.
 
 Através desta documentação deverá ser possível fazer a integração com a API do Focus NFe, caso alguma dúvida permaneça você pode entrar em contato com o suporte especializado através do e-mail suporte@focusnfe.com.br.
 
@@ -19,7 +20,7 @@ GET|/v2/nfes_recebidas/CHAVE/carta_correcao.xml|Se existir, baixa o XML da últi
 
 ## Status API
 
-Aqui você encontra os status possíveis para MDe.
+Aqui você encontra os status possíveis para NFe recebidas.
 
 HTTP CODE/STATUS | Status API Focus | Descrição | Correção
 ---|---|---|---|

--- a/source/includes/_nfses-recebidas.md
+++ b/source/includes/_nfses-recebidas.md
@@ -1,6 +1,6 @@
 # NFSes Recebidas
 
-De forma similar à [manifestação de NFe](#manifestacao-nfe), a API Focus para busca de _NFSes Recebidas_ permite que você consulte notas de serviço em que sua empresa é a tomadora do serviço. Denominamos _notas recebidas_ pois NFSe não contempla a operação de manifestação.
+De forma similar à [NFe recebidas](#nfe-recebidas), a API Focus para busca de _NFSes Recebidas_ permite que você consulte notas de serviço em que sua empresa é a tomadora do serviço. Denominamos _notas recebidas_ pois NFSe não contempla a operação de manifestação.
 
 A recuperação de notas é possível apenas em municípios que disponibilizam a consulta de notas recebidas / tomadas - como São Paulo, Sorocaba, Barueri e outras dezenas de [municípios integrados em nossa API](https://focusnfe.com.br/cidades-integradas-nfse/).
 

--- a/source/includes/_webhooks.md
+++ b/source/includes/_webhooks.md
@@ -21,7 +21,7 @@ Gatilhos ou "WebHooks" são eventos automáticos que são disparados a partir de
 }
 ```
 
-Para NFe e MDe (Manifestação de Destinatário Eletrônica):
+Para NFe e NFe recebidas (Manifestação de Destinatário Eletrônica - MDe):
 
 * **status**:
   - **processando_autorizacao**: A nota ainda está em processamento pela API. Você deverá aguardar o processamento pela SEFAZ.

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -67,7 +67,7 @@ Caso você emita NFe ou NFCe, você deverá ler também sobre os [backups](#back
 
 Caso você emita NFe ou NFSe, você poderá ler também sobre os [gatilhos e webhooks](#gatilhos-webhooks). O uso de gatilhos no sistema é opcional.
 
-Caso você tenha interesse em obter as notas emitidas contra a sua empresa, leia a seção de [manifestação](#manifestacao-nfe).
+Caso você tenha interesse em obter as notas emitidas contra a sua empresa, leia a seção de [Nfe recebidas](#nfe-recebidas).
 
 Se sua empresa irá administrar vários clientes que emitem notas, pode ser interessante você ler sobre a seção de [empresas](#empresas).
 

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -67,7 +67,7 @@ Caso você emita NFe ou NFCe, você deverá ler também sobre os [backups](#back
 
 Caso você emita NFe ou NFSe, você poderá ler também sobre os [gatilhos e webhooks](#gatilhos-webhooks). O uso de gatilhos no sistema é opcional.
 
-Caso você tenha interesse em obter as notas emitidas contra a sua empresa, leia a seção de [Nfe recebidas](#nfe-recebidas).
+Caso você tenha interesse em obter as notas emitidas contra a sua empresa, leia a seção de [NFe recebidas](#nfe-recebidas).
 
 Se sua empresa irá administrar vários clientes que emitem notas, pode ser interessante você ler sobre a seção de [empresas](#empresas).
 


### PR DESCRIPTION
Origem: COPROD

Considerações adicionais: Egon, veja se era isso o esperado. Eu conferi levantando a doc localmente e as rotas continuam funcionais. Se alterei em algum lugar que vc achei melhor continuar com o termo manifestação, é só me avisar que conserto aqui. =)
