### PR TITLE
Corrige documentação de encerramento MDFe

### DIFF
--- a/source/includes/_mdfe.md
+++ b/source/includes/_mdfe.md
@@ -430,7 +430,7 @@ Encerrar uma MDF-e autorizada:
 
 `https://api.focusnfe.com.br/v2/mdfe/REFERENCIA/encerrar`
 
-Utilize o comando **HTTP POST** para incluir um condutor. Este método é síncrono, ou seja, a comunicação com a SEFAZ será feita imediatamente e devolvida a resposta na mesma requisição.
+Utilize o comando **HTTP POST** para encerrar o MDFe. Este método é síncrono, ou seja, a comunicação com a SEFAZ será feita imediatamente e devolvida a resposta na mesma requisição.
 
 Os parâmetros de encerramento deverão ser enviados da seguinte forma:
 


### PR DESCRIPTION
Origem: observado em https://redmine.focusnfe.com.br/issues/10174

Nada demais, erro de CTRL+C/CTRL+V.

> PS: Não sei o ideal é é `MDFe` ou `MDF-e`, a documentação usa ambos _à rolê_.
