### PR TITLE
Corrige os paths que apontavam para /notas_fiscais_servico/

### DIFF
--- a/source/includes/_lote_rps.md
+++ b/source/includes/_lote_rps.md
@@ -879,7 +879,6 @@ Algumas prefeituras disponibilizam um arquivo de resposta, que poderá informar 
   "numero":"9999",
   "codigo_verificacao":"311299647",
   "data_emissao":"2017-09-09T10:20:00-03:00",
-  "uri":"https://www.barueri.sp.gov.br/nfe/",
-  "caminho_xml_nota_fiscal":"/notas_fiscais_servico/NFSe191517072001883518800-1898781-9999-312276647.xml"
+  "uri":"https://www.barueri.sp.gov.br/nfe/"
 }
 ```

--- a/source/includes/_nfse.md
+++ b/source/includes/_nfse.md
@@ -775,7 +775,7 @@ console.log("Corpo: " + request.responseText);
   "codigo_verificacao": "DU1M-M2Y",
   "data_emissao": "2019-05-27T00:00:00-03:00",
   "url": "https://200.189.192.82/PilotoNota_Portal/Default.aspx?doc=07504505000132&num=233&cod=DUMMY",
-  "caminho_xml_nota_fiscal": "/notas_fiscais_servico/NFSe075045050001324106902-004949940-433-DUMMY.xml"
+  "caminho_xml_nota_fiscal": "/arquivos/07504505000132_12345/202401/XMLsNFSe/075045050001324106902-004949940-433-DUMMY-nfse.xml"
 }
 ```
 
@@ -792,7 +792,8 @@ console.log("Corpo: " + request.responseText);
   "codigo_verificacao": "DU1M-M2Y",
   "data_emissao": "2019-05-27T00:00:00-03:00",
   "url": "https://200.189.192.82/PilotoNota_Portal/Default.aspx?doc=07504505000132&num=233&cod=DUMMY",
-  "caminho_xml_nota_fiscal": "/notas_fiscais_servico/NFSe075045050001324106902-004949940-433-DUMMY.xml"
+  "caminho_xml_nota_fiscal": "/arquivos/07504505000132_12345/202401/XMLsNFSe/075045050001324106902-004949940-433-DUMMY-nfse.xml",
+  "caminho_xml_cancelamento": "/arquivos/07504505000132_12345/202401/XMLsNFSe/075045050001324106902-004949940-433-DUMMY-can.xml"
 }
 ```
 
@@ -863,7 +864,7 @@ Utilize o comando **HTTP GET** para consultar a sua nota para nossa API.
 
 Após a autorização da nota fiscal de serviço eletrônica será disponibilizado os campos:
 
-*  **caminho_xml_nota_fiscal** - Representa o caminho para montar a URL para download do XML. Por exemplo, se você utilizou o servidor api.focusnfe.com.br e o caminho_xml_nota_fiscal contém o caminho "/notas_fiscais_servico/NFSe075045050001324106902-004940940-428-DUMMY.xml" você poderá acessar o XML pela URL completa https://api.focusnfe.com.br/notas_fiscais_servico/NFSe075045050001324106902-004940940-428-DUMMY.xml
+*  **caminho_xml_nota_fiscal** - Representa o caminho para montar a URL para download do XML. Por exemplo, se você utilizou o servidor api.focusnfe.com.br e o caminho_xml_nota_fiscal contém o caminho "/arquivos/07504505000132_12345/202401/XMLsNFSe/075045050001324106902-004949940-433-DUMMY-nfse.xml" você poderá acessar o XML pela URL completa https://api.focusnfe.com.br/arquivos/07504505000132_12345/202401/XMLsNFSe/075045050001324106902-004949940-433-DUMMY-nfse.xml
 * **url**. A URL para consultar a NFSe direto no portal da prefeitura.
 
 Utilize o método **HTTP GET** para ambas as consultas.

--- a/source/includes/_nfsen.md
+++ b/source/includes/_nfsen.md
@@ -743,7 +743,7 @@ Utilize o comando **HTTP GET** para consultar a sua nota para nossa API.
 
 Após a autorização da nota fiscal de serviço eletrônica será disponibilizado os campos:
 
-*  **caminho_xml_nota_fiscal** - Representa o caminho para montar a URL para download do XML. Por exemplo, se você utilizou o servidor api.focusnfe.com.br e o caminho_xml_nota_fiscal contém o caminho "/notas_fiscais_servico/NFSe075045050001324106902-004940940-428-DUMMY.xml" você poderá acessar o XML pela URL completa https://api.focusnfe.com.br/notas_fiscais_servico/NFSe075045050001324106902-004940940-428-DUMMY.xml
+*  **caminho_xml_nota_fiscal** - Representa o caminho para montar a URL para download do XML. Por exemplo, se você utilizou o servidor api.focusnfe.com.br e o caminho_xml_nota_fiscal contém o caminho "/arquivos/18765499000199_166/202405/XMLsNFSe/187654990001994106902-14018919393-43-12345678901234567890123456789012345678901234567890-nfse.xml" você poderá acessar o XML pela URL completa https://api.focusnfe.com.br/arquivos/18765499000199_166/202405/XMLsNFSe/187654990001994106902-14018919393-43-12345678901234567890123456789012345678901234567890-nfse.xml
 * **url**. A URL para consultar a NFSe direto no portal do Ambiente Nacional.
 
 Utilize o método **HTTP GET** para ambas as consultas.


### PR DESCRIPTION
Origem: Discussão daily 

Depois que começarmos a salvar os XMLs no S3, não retornamos mais o path '/notas_fiscais_servico/...' e sim o path que que aponta direto para a pasta no S3 '/arquivos/...'
