### PR TITLE
Ajusta texto do tópico "Reenvio de email" da NFS-e

### DIFF
--- a/source/includes/_nfse.md
+++ b/source/includes/_nfse.md
@@ -1383,7 +1383,7 @@ console.log("Corpo: " + request.responseText);
 
 
 
-Para cada nota autorizada, cancelada ou que tenha sido emitida uma carta de correção o destinatário da nota é notificado via email. Porém eventualmente pode ser necessário enviar a nota fiscal para outras pessoas ou mesmo reenviar o email para o mesmo destinatário.
+Para cada nota autorizada o tomador do serviço é notificado via email. Porém eventualmente pode ser necessário enviar a nota fiscal para outras pessoas ou mesmo reenviar o email para o mesmo destinatário.
 
 Para enviar um ou mais emails:
 


### PR DESCRIPTION
O texto foi ajustado para indicar que o envio automático do email ocorre apenas na autorização da NFS-e.

https://acras.freshdesk.com/a/tickets/169737